### PR TITLE
Support virtual SQL for JSON TABLE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         OCEANBASE_USER: 'root@test'
         OCEANBASE_PASS: ''
       run: |
-        docker exec ob433 obclient -h $OCEANBASE_HOST -P $OCEANBASE_PORT -u $OCEANBASE_USER -p$OCEANBASE_PASS -e "ALTER SYSTEM ob_vector_memory_limit_percentage = 30"
+        docker exec ob433 obclient -h $OCEANBASE_HOST -P $OCEANBASE_PORT -u $OCEANBASE_USER -p$OCEANBASE_PASS -e "ALTER SYSTEM ob_vector_memory_limit_percentage = 30; create user 'jtuser'@'%'; GRANT SELECT, INSERT, UPDATE, DELETE ON test.* TO 'jtuser'@'%'; FLUSH PRIVILEGES;"
 
     - name: Run tests
       run: |

--- a/pyobvector/__init__.py
+++ b/pyobvector/__init__.py
@@ -51,10 +51,12 @@ from .schema import (
     st_dwithin,
     st_astext,
 )
+from .json_table import OceanBase
 
 __all__ = [
     "ObVecClient",
     "MilvusLikeClient",
+    "ObVecJsonTableClient",
     "VecIndexType",
     "IndexParam",
     "IndexParams",
@@ -85,4 +87,5 @@ __all__ = [
     "st_distance",
     "st_dwithin",
     "st_astext",
+    "OceanBase",
 ]

--- a/pyobvector/client/__init__.py
+++ b/pyobvector/client/__init__.py
@@ -30,6 +30,7 @@ In this mode, you can regard `pyobvector` as an extension of SQLAlchemy.
 """
 from .ob_vec_client import ObVecClient
 from .milvus_like_client import MilvusLikeClient
+from .ob_vec_json_table_client import ObVecJsonTableClient
 from .index_param import VecIndexType, IndexParam, IndexParams
 from .schema_type import DataType
 from .collection_schema import FieldSchema, CollectionSchema
@@ -38,6 +39,7 @@ from .partitions import *
 __all__ = [
     "ObVecClient",
     "MilvusLikeClient",
+    "ObVecJsonTableClient",
     "VecIndexType",
     "IndexParam",
     "IndexParams",

--- a/pyobvector/client/ob_vec_json_table_client.py
+++ b/pyobvector/client/ob_vec_json_table_client.py
@@ -22,7 +22,7 @@ from ..json_table import (
 )
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
+logger.setLevel(logging.DEBUG)
 
 JSON_TABLE_META_TABLE_NAME = "_meta_json_t"
 JSON_TABLE_DATA_TABLE_NAME = "_data_json_t"

--- a/pyobvector/client/ob_vec_json_table_client.py
+++ b/pyobvector/client/ob_vec_json_table_client.py
@@ -1,0 +1,472 @@
+import json
+import logging
+from typing import Dict, List, Optional, Any
+
+from pydantic import BaseModel, create_model
+from sqlalchemy import Column, Integer, String, JSON, Engine, select
+from sqlalchemy.dialects.mysql import TINYINT
+from sqlalchemy.orm import declarative_base, sessionmaker, Session
+from sqlglot import parse_one, exp, Expression
+
+from .ob_vec_client import ObVecClient
+from ..json_table import OceanBase, ChangeColumn
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class ObVecJsonTableClient(ObVecClient):
+    """OceanBase Vector Store Client with JSON Table."""
+
+    Base = declarative_base()
+
+    class JsonTableMetaTBL(Base):
+        __tablename__ = '_meta_json_t'
+        
+        user_id = Column(Integer, primary_key=True)
+        jtable_name = Column(String(512), primary_key=True)
+        jcol_id = Column(Integer, primary_key=True)
+        jcol_name = Column(String(512), primary_key=True)
+        jcol_type = Column(String(128), nullable=False)
+        jcol_nullable = Column(TINYINT, nullable=False)
+        jcol_has_default = Column(TINYINT, nullable=False)
+        jcol_default = Column(JSON)
+
+    class JsonTableDataTBL(Base):
+        __tablename__ = '_data_json_t'
+
+        user_id = Column(Integer, primary_key=True)
+        jtable_name = Column(String(512), primary_key=True)
+        jdata_id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
+        jdata = Column(JSON)
+
+    class JsonTableMetadata:
+        def __init__(self, user_id: int):
+            self.user_id = user_id
+            self.meta_cache: Dict[str, List] = {}
+            # self.model: Dict[str, BaseModel] = {}
+
+        # def _create_dynamic_model(self, model_name: str, col_meta_list: List[Dict[str, Any]]) -> BaseModel:
+        #     model_fields = {}
+        #     for col_meta in col_meta_list:
+        #         if col_meta['jcol_type'] == "TINYINT":
+        #             if not col_meta['jcol_has_default']:
+        #                 model_fields[col_meta['jcol_name']] = (str, ...)
+                    
+        #     pass
+            # return create_model(model_name, **fields)
+
+        def reflect(self, engine: Engine):
+            self.meta_cache = {}
+            with engine.connect() as conn:
+                with conn.begin():
+                    stmt = select(ObVecJsonTableClient.JsonTableMetaTBL).filter(
+                        ObVecJsonTableClient.JsonTableMetaTBL.user_id == self.user_id
+                    )
+                    res = conn.execute(stmt)
+                    for r in res:
+                        if r[1] not in self.meta_cache:
+                            self.meta_cache[r[1]] = []
+                        self.meta_cache[r[1]].append({
+                            'jcol_id': r[2],
+                            'jcol_name': r[3],
+                            'jcol_type': r[4],
+                            'jcol_nullable': bool(r[5]),
+                            'jcol_has_default': bool(r[6]),
+                            'jcol_default': (
+                                r[7]['default']
+                                if isinstance(r[7], dict) else
+                                json.loads(r[7])['default']
+                            ),
+                        })
+                    for k, _ in self.meta_cache.items():
+                        self.meta_cache[k].sort(key=lambda x: x['jcol_id'])
+
+                    for k, v in self.meta_cache.items():
+                        logger.info(f"LOAD TABLE --- {k}: {v}")
+
+
+    def __init__(
+        self,
+        user_id: int,
+        uri: str = "127.0.0.1:2881",
+        user: str = "root@test",
+        password: str = "",
+        db_name: str = "test",
+        **kwargs,
+    ):
+        super().__init__(uri, user, password, db_name, **kwargs)
+        self.Base.metadata.create_all(self.engine)
+        self.user_id = user_id
+        self.jmetadata = ObVecJsonTableClient.JsonTableMetadata(self.user_id)
+        self.jmetadata.reflect(self.engine)
+
+    def perform_json_table_sql(self, sql: str):
+        """Perform common SQL that operates on JSON Table."""
+        ast = parse_one(sql, dialect="oceanbase")
+        if isinstance(ast, exp.Create):
+            if ast.kind and ast.kind == 'TABLE':
+                self._handle_create_json_table(ast)
+            else:
+                raise ValueError(f"Create {ast.kind} is not supported")
+        elif isinstance(ast, exp.Alter):
+            self._handle_alter_json_table(ast)
+        elif isinstance(ast, exp.Insert):
+            self._handle_jtable_dml_insert(ast)
+        
+    def _parse_datatype_to_str(self, datatype):
+        if datatype == exp.DataType.Type.INT:
+            return "INT"
+        if datatype == exp.DataType.Type.TINYINT:
+            return "TINYINT"
+        if datatype == exp.DataType.Type.TIMESTAMP:
+            return "TIMESTAMP"
+        if datatype == exp.DataType.Type.VARCHAR:
+            return "VARCHAR"
+        if datatype == exp.DataType.Type.DECIMAL:
+            return "DECIMAL"
+        raise ValueError(f"{datatype} not supported")
+    
+    def _handle_create_json_table(self, ast: Expression):
+        logger.info("HANDLE CREATE JSON TABLE")
+
+        if not isinstance(ast.this, exp.Schema):
+            raise ValueError("Invalid create table statement")
+        schema = ast.this
+        if not isinstance(schema.this, exp.Table):
+            raise ValueError("Invalid create table statement")
+        jtable = schema.this
+        if not isinstance(jtable.this, exp.Identifier):
+            raise ValueError("Invalid create table statement")
+        jtable_name = jtable.this.this
+        logger.info(jtable_name)
+
+        if jtable_name in self.jmetadata.meta_cache:
+            raise ValueError("Table name duplicated")
+        
+        Session = sessionmaker(bind=self.engine)
+        session = Session()
+        new_meta_cache_items = []
+        col_id = 16
+        for col_def in ast.find_all(exp.ColumnDef):
+            col_name = col_def.this.this
+            col_type_str = self._parse_datatype_to_str(col_def.kind.this)
+            col_type_str_prefix = col_type_str
+            col_type_params = col_def.kind.expressions
+            col_type_params_list = []
+            col_nullable = True
+            col_has_default = False
+            col_default_val = None
+            for param in col_type_params:
+                if param.is_string:
+                    col_type_params_list.append(f"'{param.this}'")
+                else:
+                    col_type_params_list.append(f"{param.this}")
+            if len(col_type_params_list) > 0:
+                col_type_str += '(' + ','.join(col_type_params_list) + ')'
+            
+            for cons in col_def.constraints:
+                if isinstance(cons.kind, exp.DefaultColumnConstraint):
+                    col_has_default = True
+                    # if cons.kind.this.is_string or (col_type_str_prefix in ["VARCHAR"]):
+                    #     col_default_val = "\'" + cons.kind.this.this + "\'"
+                    # else:
+                    col_default_val = cons.kind.this.this
+                elif isinstance(cons.kind, exp.NotNullColumnConstraint):
+                    col_nullable = False
+                else:
+                    raise ValueError(f"{cons.kind} constriaint is not supported.")
+            
+            if (not col_nullable) and col_has_default and (col_default_val is None):
+                raise ValueError(f"Invalid default value for '{col_name}'")
+
+            logger.info(
+                f"col_name={col_name}, col_id={col_id}, "
+                f"col_type_str={col_type_str}, col_nullable={col_nullable}, "
+                f"col_has_default={col_has_default}, col_default_val={col_default_val}"
+            )
+            new_meta_cache_items.append({
+                'jcol_id': col_id,
+                'jcol_name': col_name,
+                'jcol_type': col_type_str,
+                'jcol_nullable': col_nullable,
+                'jcol_has_default': col_has_default,
+                'jcol_default': col_default_val,
+            })
+            session.add(ObVecJsonTableClient.JsonTableMetaTBL(
+                user_id = self.user_id,
+                jtable_name = jtable_name,
+                jcol_id = col_id,
+                jcol_name = col_name,
+                jcol_type = col_type_str,
+                jcol_nullable = col_nullable,
+                jcol_has_default = col_has_default,
+                jcol_default = {
+                    'default': col_default_val,
+                }
+            ))
+            
+            col_id += 1
+        
+        try:
+            session.commit()
+            self.jmetadata.meta_cache[jtable_name] = new_meta_cache_items
+            logger.info(f"ADD METADATA CACHE ---- {jtable_name}: {new_meta_cache_items}")
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Error occurred: {e}")
+        finally:
+            session.close()
+
+    def _check_table_exists(self, jtable_name: str) -> bool:
+        return jtable_name in self.jmetadata.meta_cache
+    
+    def _check_col_exists(self, jtable_name: str, col_name: str) -> Optional[Dict]:
+        if not self._check_table_exists(jtable_name):
+            return None
+        for col_meta in self.jmetadata.meta_cache[jtable_name]:
+            if col_meta['jcol_name'] == col_name:
+                return col_meta
+        return None
+    
+    def _parse_col_datatype(self, expr: Expression) -> str:
+        col_type_str = self._parse_datatype_to_str(expr.this)
+        col_type_params_list = []
+        for param in expr.expressions:
+            if param.is_string:
+                col_type_params_list.append(f"'{param.this}'")
+            else:
+                col_type_params_list.append(f"{param.this}")
+        if len(col_type_params_list) > 0:
+            col_type_str += '(' + ','.join(col_type_params_list) + ')'
+        return col_type_str
+    
+    def _parse_col_constraints(self, expr: Expression, datatype) -> Dict:
+        col_has_default = False
+        col_nullable = True
+        for cons in expr:
+            if isinstance(cons.kind, exp.DefaultColumnConstraint):
+                col_has_default = True
+                # if cons.kind.this.is_string or (self._parse_datatype_to_str(datatype) in ["VARCHAR"]):
+                #     col_default_val = "\'" + cons.kind.this.this + "\'"
+                # else:
+                col_default_val = cons.kind.this.this
+            elif isinstance(cons.kind, exp.NotNullColumnConstraint):
+                col_nullable = False
+            else:
+                raise ValueError(f"{cons.kind} constriaint is not supported.")
+        return {
+            'jcol_nullable': col_nullable,
+            'jcol_has_default': col_has_default,
+            'jcol_default': col_default_val,
+        }
+
+    def _handle_alter_jtable_change_column(
+        self,
+        session: Session,
+        jtable_name: str,
+        change_col: Expression,
+    ):
+        logger.info("HANDLE ALTER CHANGE COLUMN")
+        origin_col_name = change_col.origin_col_name.this
+        if not self._check_col_exists(jtable_name, origin_col_name):
+            raise ValueError(f"{origin_col_name} not exists in {jtable_name}")
+        
+        new_col_name = change_col.this
+        if self._check_col_exists(jtable_name, new_col_name):
+            raise ValueError(f"Column {new_col_name} exists!")
+        
+        col_type_str = self._parse_col_datatype(change_col.dtype)
+
+        session.query(ObVecJsonTableClient.JsonTableMetaTBL).filter_by(
+            user_id=self.user_id,
+            jtable_name=jtable_name,
+            jcol_name=origin_col_name
+        ).update({
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_name: new_col_name,
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_type: col_type_str,
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_nullable: True,
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_has_default: True,
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_default: {
+                'default': None
+            },
+        })
+
+        # TODO: update json data
+
+
+    def _handle_alter_jtable_drop_column(
+        self,
+        session: Session,
+        jtable_name: str,
+        drop_col: Expression,
+    ):
+        logger.info("HANDLE ALTER DROP COLUMN")
+        if not isinstance(drop_col.this, exp.Column):
+            raise ValueError(f"Drop {drop_col.kind} is not supported")
+        col_name = drop_col.this.this.this
+        if not self._check_col_exists(jtable_name, col_name):
+            raise ValueError(f"{col_name} not exists in {jtable_name}")
+
+        session.query(ObVecJsonTableClient.JsonTableMetaTBL).filter_by(
+            user_id=self.user_id,
+            jtable_name=jtable_name,
+            jcol_name=col_name
+        ).delete()
+
+        # TODO: update json data
+
+    def _handle_alter_jtable_add_column(
+        self,
+        session: Session,
+        jtable_name: str,
+        add_col: Expression,
+    ):
+        logger.info("HANDLE ALTER ADD COLUMN")
+        new_col_name = add_col.this.this
+        if self._check_col_exists(jtable_name, new_col_name):
+            raise ValueError(f"{new_col_name} exists!")
+        
+        col_type_str = self._parse_col_datatype(add_col.kind)
+        constraints = self._parse_col_constraints(add_col.constraints, add_col.kind.this)
+        cur_col_id = max([meta['jcol_id'] for meta in self.jmetadata.meta_cache[jtable_name]]) + 1
+
+        session.add(ObVecJsonTableClient.JsonTableMetaTBL(
+            user_id = self.user_id,
+            jtable_name = jtable_name,
+            jcol_id = cur_col_id,
+            jcol_name = new_col_name,
+            jcol_type = col_type_str,
+            jcol_nullable = constraints['jcol_nullable'],
+            jcol_has_default = constraints['jcol_has_default'],
+            jcol_default = {
+                'default': constraints['jcol_default'],
+            }
+        ))
+
+        # TODO: update json data
+
+    def _handle_alter_jtable_modify_column(
+        self,
+        session: Session,
+        jtable_name: str,
+        modify_col: Expression,
+    ):
+        logger.info("HANDLE ALTER MODIFY COLUMN")
+        col_def = modify_col.this
+        col_name = col_def.this.this
+        if not self._check_col_exists(jtable_name, col_name):
+            raise ValueError(f"{col_name} not exists in {jtable_name}")
+        
+        col_type_str = self._parse_col_datatype(col_def.kind)
+        constraints = self._parse_col_constraints(col_def.constraints, col_def.kind.this)
+
+        session.query(ObVecJsonTableClient.JsonTableMetaTBL).filter_by(
+            user_id=self.user_id,
+            jtable_name=jtable_name,
+            jcol_name=col_name
+        ).update({
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_name: col_name,
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_type: col_type_str,
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_nullable: constraints['jcol_nullable'],
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_has_default: constraints['jcol_has_default'],
+            ObVecJsonTableClient.JsonTableMetaTBL.jcol_default: {
+                'default': constraints['jcol_default']
+            },
+        })
+
+        # TODO: update json data
+
+    def _handle_alter_jtable_rename_table(
+        self,
+        session: Session,
+        jtable_name: str,
+        rename: Expression,
+    ):
+        if not self._check_table_exists(jtable_name):
+            raise ValueError(f"Table {jtable_name} does not exists")
+        
+        new_table_name = rename.this.this.this
+        if self.check_table_exists(new_table_name):
+            raise ValueError(f"Table {new_table_name} exists!")
+        
+        session.query(ObVecJsonTableClient.JsonTableMetaTBL).filter_by(
+            user_id=self.user_id,
+            jtable_name=jtable_name,
+        ).update({
+            ObVecJsonTableClient.JsonTableMetaTBL.jtable_name: new_table_name,
+        })
+
+    def _handle_alter_json_table(self, ast: Expression):
+        if not isinstance(ast.this, exp.Table):
+            raise ValueError("Invalid alter table statement")
+        if not isinstance(ast.this.this, exp.Identifier):
+            raise ValueError("Invalid create table statement")
+        jtable_name = ast.this.this.this
+        if not self._check_table_exists(jtable_name):
+            raise ValueError(f"Table {jtable_name} does not exists")
+        
+        Session = sessionmaker(bind=self.engine)
+        session = Session()
+        for action in ast.actions:
+            if isinstance(action, ChangeColumn):
+                self._handle_alter_jtable_change_column(
+                    session,
+                    jtable_name,
+                    action,
+                )
+            if isinstance(action, exp.Drop):
+                self._handle_alter_jtable_drop_column(
+                    session,
+                    jtable_name,
+                    action,
+                )
+            if isinstance(action, exp.AlterColumn):
+                self._handle_alter_jtable_modify_column(
+                    session,
+                    jtable_name,
+                    action,
+                )
+            if isinstance(action, exp.ColumnDef):
+                self._handle_alter_jtable_add_column(
+                    session,
+                    jtable_name,
+                    action,
+                )
+            if isinstance(action, exp.AlterRename):
+                self._handle_alter_jtable_rename_table(
+                    session,
+                    jtable_name,
+                    action,
+                )
+        
+        try:
+            session.commit()
+            self.jmetadata.reflect(self.engine)
+        except Exception as e:
+            session.rollback()
+            logger.error(f"Error occurred: {e}")
+        finally:
+            session.close()
+
+    def _handle_jtable_dml_insert(self, ast: Expression):
+        if isinstance(ast.this, exp.Schema):
+            table_name = ast.this.this.this.this
+            insert_col_names = [expr.this for expr in ast.this.expressions]
+            table_col_names = [meta['jcol_name'] for meta in self.jmetadata.meta_cache[table_name]]
+            for col_name in insert_col_names:
+                if col_name not in table_col_names:
+                    raise ValueError(f"Unknown column {col_name} in field list")
+            cols = []
+            for meta in self.jmetadata.meta_cache[table_name]:
+                if ((meta['jcol_name'] not in insert_col_names) and
+                    (not meta['jcol_nullable']) and (not meta['jcol_has_default'])):
+                    raise ValueError(f"Field {meta['jcol_name']} does not have a default value")
+                cols.append(meta)
+        elif isinstance(ast.this, exp.Table):
+            table_name = ast.this.this.this
+            cols = self.jmetadata.meta_cache[table_name]
+
+        for tuple in ast.expression.expressions:
+            
+            pass

--- a/pyobvector/json_table/__init__.py
+++ b/pyobvector/json_table/__init__.py
@@ -1,3 +1,21 @@
 from .oceanbase_dialect import OceanBase, ChangeColumn
+from .virtual_data_type import (
+    JType,
+    JsonTableDataType,
+    JsonTableBool,
+    JsonTableTimestamp,
+    JsonTableVarcharFactory,
+    JsonTableDecimalFactory,
+    JsonTableInt,
+)
 
-__all__ = ["OceanBase", "ChangeColumn"]
+__all__ = [
+    "OceanBase", "ChangeColumn",
+    "JType",
+    "JsonTableDataType",
+    "JsonTableBool",
+    "JsonTableTimestamp",
+    "JsonTableVarcharFactory",
+    "JsonTableDecimalFactory",
+    "JsonTableInt",
+]

--- a/pyobvector/json_table/__init__.py
+++ b/pyobvector/json_table/__init__.py
@@ -7,6 +7,7 @@ from .virtual_data_type import (
     JsonTableVarcharFactory,
     JsonTableDecimalFactory,
     JsonTableInt,
+    val2json,
 )
 
 __all__ = [
@@ -18,4 +19,5 @@ __all__ = [
     "JsonTableVarcharFactory",
     "JsonTableDecimalFactory",
     "JsonTableInt",
+    "val2json",
 ]

--- a/pyobvector/json_table/__init__.py
+++ b/pyobvector/json_table/__init__.py
@@ -9,6 +9,7 @@ from .virtual_data_type import (
     JsonTableInt,
     val2json,
 )
+from .json_value_returning_func import json_value
 
 __all__ = [
     "OceanBase", "ChangeColumn",
@@ -20,4 +21,5 @@ __all__ = [
     "JsonTableDecimalFactory",
     "JsonTableInt",
     "val2json",
+    "json_value"
 ]

--- a/pyobvector/json_table/__init__.py
+++ b/pyobvector/json_table/__init__.py
@@ -1,0 +1,3 @@
+from .oceanbase_dialect import OceanBase, ChangeColumn
+
+__all__ = ["OceanBase", "ChangeColumn"]

--- a/pyobvector/json_table/json_value_returning_func.py
+++ b/pyobvector/json_table/json_value_returning_func.py
@@ -1,0 +1,51 @@
+import logging
+import re
+from typing import Tuple
+
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.functions import FunctionElement
+from sqlalchemy import BINARY, Float, Boolean, Text
+
+logger = logging.getLogger(__name__)
+
+class json_value(FunctionElement):
+    type = Text()
+    inherit_cache = True
+
+    def __init__(self, *args):
+        super().__init__()
+        self.args = args
+
+@compiles(json_value)
+def compile_json_value(element, compiler, **kwargs):
+    args = []
+    if len(element.args) != 3:
+        raise ValueError("Number of args for json_value should be 3")
+    args.append(compiler.process(element.args[0]))
+    if not (isinstance(element.args[1], str) and isinstance(element.args[2], str)):
+        raise ValueError("Invalid args for json_value")
+    
+    if element.args[2].startswith('TINYINT'):
+        returning_type = "SIGNED"
+    elif element.args[2].startswith('TIMESTAMP'):
+        returning_type = "DATETIME"
+    elif element.args[2].startswith('INT'):
+        returning_type = "SIGNED"
+    elif element.args[2].startswith('VARCHAR'):
+        if element.args[2] == 'VARCHAR':
+            returning_type = "CHAR(255)"
+        else:
+            varchar_pattern = r'VARCHAR\((\d+)\)'
+            varchar_matches = re.findall(varchar_pattern, element.args[2])
+            returning_type = f"CHAR({int(varchar_matches[0])})"
+    elif element.args[2].startswith('DECIMAL'):
+        if element.args[2] == 'DECIMAL':
+            returning_type = "DECIMAL(10, 0)"
+        else:
+            decimal_pattern = r'DECIMAL\((\d+),\s*(\d+)\)'
+            decimal_matches = re.findall(decimal_pattern, element.args[2])
+            x, y = decimal_matches[0]
+            returning_type = f"DECIMAL({x}, {y})"
+    args.append(f"'{element.args[1]}' RETURNING {returning_type}")
+    args = ", ".join(args)
+    return f"json_value({args})"

--- a/pyobvector/json_table/oceanbase_dialect.py
+++ b/pyobvector/json_table/oceanbase_dialect.py
@@ -1,0 +1,116 @@
+import typing as t
+from sqlglot import parser, exp, Expression
+from sqlglot.dialects.mysql import MySQL
+from sqlglot.tokens import TokenType
+
+class ChangeColumn(Expression):
+    arg_types = {
+        "this": True,
+        "origin_col_name": True,
+        "dtype": True,
+    }
+
+    @property
+    def origin_col_name(self) -> str:
+        origin_col_name = self.args.get("origin_col_name")
+        return origin_col_name
+    
+    @property
+    def dtype(self) -> Expression:
+        dtype = self.args.get("dtype")
+        return dtype
+
+class OceanBase(MySQL):
+    class Parser(MySQL.Parser):
+        ALTER_PARSERS = {
+            **parser.Parser.ALTER_PARSERS,
+            "MODIFY": lambda self: self._parse_alter_table_alter(),
+            "CHANGE": lambda self: self._parse_change_table_column(),
+        }
+        
+        def _parse_alter_table_alter(self) -> t.Optional[exp.Expression]:
+            if self._match_texts(self.ALTER_ALTER_PARSERS):
+                return self.ALTER_ALTER_PARSERS[self._prev.text.upper()](self)
+
+            self._match(TokenType.COLUMN)
+            column = self._parse_field_def()
+
+            if self._match_pair(TokenType.DROP, TokenType.DEFAULT):
+                return self.expression(exp.AlterColumn, this=column, drop=True)
+            if self._match_pair(TokenType.SET, TokenType.DEFAULT):
+                return self.expression(exp.AlterColumn, this=column, default=self._parse_assignment())
+            if self._match(TokenType.COMMENT):
+                return self.expression(exp.AlterColumn, this=column, comment=self._parse_string())
+            if self._match_text_seq("DROP", "NOT", "NULL"):
+                return self.expression(
+                    exp.AlterColumn,
+                    this=column,
+                    drop=True,
+                    allow_null=True,
+                )
+            if self._match_text_seq("SET", "NOT", "NULL"):
+                return self.expression(
+                    exp.AlterColumn,
+                    this=column,
+                    allow_null=False,
+                )
+            self._match_text_seq("SET", "DATA")
+            self._match_text_seq("TYPE")
+            return self.expression(
+                exp.AlterColumn,
+                this=column,
+                dtype=self._parse_types(),
+                collate=self._match(TokenType.COLLATE) and self._parse_term(),
+                using=self._match(TokenType.USING) and self._parse_assignment(),
+            )
+        
+        def _parse_drop(self, exists: bool = False) -> exp.Drop | exp.Command:
+            temporary = self._match(TokenType.TEMPORARY)
+            materialized = self._match_text_seq("MATERIALIZED")
+
+            kind = self._match_set(self.CREATABLES) and self._prev.text.upper()
+            if not kind:
+                kind = "COLUMN"
+
+            concurrently = self._match_text_seq("CONCURRENTLY")
+            if_exists = exists or self._parse_exists()
+
+            if kind == "COLUMN":
+                this = self._parse_column()
+            else:
+                this = self._parse_table_parts(
+                    schema=True, is_db_reference=self._prev.token_type == TokenType.SCHEMA
+                )
+
+            cluster = self._parse_on_property() if self._match(TokenType.ON) else None
+
+            if self._match(TokenType.L_PAREN, advance=False):
+                expressions = self._parse_wrapped_csv(self._parse_types)
+            else:
+                expressions = None
+
+            return self.expression(
+                exp.Drop,
+                exists=if_exists,
+                this=this,
+                expressions=expressions,
+                kind=self.dialect.CREATABLE_KIND_MAPPING.get(kind) or kind,
+                temporary=temporary,
+                materialized=materialized,
+                cascade=self._match_text_seq("CASCADE"),
+                constraints=self._match_text_seq("CONSTRAINTS"),
+                purge=self._match_text_seq("PURGE"),
+                cluster=cluster,
+                concurrently=concurrently,
+            )
+        
+        def _parse_change_table_column(self) -> t.Optional[exp.Expression]:
+            self._match(TokenType.COLUMN)
+            origin_col = self._parse_field(any_token=True)
+            column = self._parse_field()
+            return self.expression(
+                ChangeColumn,
+                this=column,
+                origin_col_name=origin_col,
+                dtype=self._parse_types(),
+            )

--- a/pyobvector/json_table/virtual_data_type.py
+++ b/pyobvector/json_table/virtual_data_type.py
@@ -1,0 +1,4 @@
+# class 
+from ..client import IntEnum
+
+# class VirtualDataType(IntEnum):

--- a/pyobvector/json_table/virtual_data_type.py
+++ b/pyobvector/json_table/virtual_data_type.py
@@ -1,4 +1,104 @@
-# class 
-from ..client import IntEnum
+from datetime import datetime
+from decimal import Decimal, InvalidOperation, ROUND_DOWN
+from enum import Enum
+from typing import Optional
+from typing_extensions import Annotated
 
-# class VirtualDataType(IntEnum):
+from pydantic import BaseModel, Field, AfterValidator, create_model
+
+
+class IntEnum(int, Enum):
+    """Int type enumerate definition."""
+
+class JType(IntEnum):
+    J_BOOL = 1
+    J_TIMESTAMP = 2
+    J_VARCHAR = 3
+    J_DECIMAL = 4
+    J_INT = 5
+
+class JsonTableDataType(BaseModel):
+    type: JType
+
+class JsonTableBool(JsonTableDataType):
+    type: JType = Field(default=JType.J_BOOL)
+    val: Optional[bool]
+
+class JsonTableTimestamp(JsonTableDataType):
+    type: JType = Field(default=JType.J_TIMESTAMP)
+    val: Optional[datetime]
+
+def check_varchar_len_with_length(length: int):
+    def check_varchar_len(x: Optional[str]):
+        if x is None:
+            return None
+        if len(x) > length:
+            raise ValueError(f'{x} is longer than {length}')
+        return x
+    
+    return check_varchar_len
+
+class JsonTableVarcharFactory:
+    def __init__(self, length: int):
+        self.length = length
+
+    def get_json_table_varchar_type(self):
+        model_name = f"JsonTableVarchar{self.length}"
+        fields = {
+            'type': (JType, JType.J_VARCHAR),
+            'val': (Annotated[Optional[str], AfterValidator(check_varchar_len_with_length(self.length))], ...)
+        }
+        return create_model(
+            model_name,
+            __base__=JsonTableDataType,
+            **fields
+        )
+
+def check_and_parse_decimal(x: int, y: int):
+    def check_float(v):
+        if v is None:
+            return None
+        try:
+            decimal_value = Decimal(v)
+        except InvalidOperation:
+            raise ValueError(f"Value {v} cannot be converted to Decimal.")
+        
+        decimal_str = str(decimal_value).strip()
+    
+        if '.' in decimal_str:
+            integer_part, decimal_part = decimal_str.split('.')
+        else:
+            integer_part, decimal_part = decimal_str, ''
+    
+        integer_count = len(integer_part.lstrip('-'))  # 去掉负号的长度
+        decimal_count = len(decimal_part)
+
+        if integer_count + min(decimal_count, y) > x:
+            raise ValueError(f"'{v}' Range out of Decimal({x}, {y})")
+        
+        if decimal_count > y:
+            quantize_str = '1.' + '0' * y
+            decimal_value = decimal_value.quantize(Decimal(quantize_str), rounding=ROUND_DOWN)
+        return decimal_value
+    return check_float
+
+class JsonTableDecimalFactory:
+    def __init__(self, ndigits: int, decimal_p: int):
+        self.ndigits = ndigits
+        self.decimal_p = decimal_p
+    
+    def get_json_table_decimal_type(self):
+        model_name = f"JsonTableDecimal_{self.ndigits}_{self.decimal_p}"
+        fields = {
+            'type': (JType, JType.J_DECIMAL),
+            'val': (Annotated[Optional[float], AfterValidator(check_and_parse_decimal(self.ndigits, self.decimal_p))], ...)
+        }
+        return create_model(
+            model_name,
+            __base__=JsonTableDataType,
+            **fields
+        )
+
+class JsonTableInt(JsonTableDataType):
+    type: JType = Field(default=JType.J_INT)
+    val: Optional[int]

--- a/pyobvector/json_table/virtual_data_type.py
+++ b/pyobvector/json_table/virtual_data_type.py
@@ -102,3 +102,13 @@ class JsonTableDecimalFactory:
 class JsonTableInt(JsonTableDataType):
     type: JType = Field(default=JType.J_INT)
     val: Optional[int]
+
+def val2json(val):
+    if val is None:
+        return None
+    if isinstance(val, int) or isinstance(val, bool) or isinstance(val, str):
+        return val
+    if isinstance(val, datetime):
+        return val.isoformat()
+    if isinstance(val, Decimal):
+        return float(val)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ numpy = ">=1.26.0,<2.0.0"
 sqlalchemy = ">=1.4,<2.0.36"
 pymysql = "^1.1.1"
 aiomysql = "^0.2.0"
+sqlglot = "^26.0.1"
+pydantic = "^2.10.4"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.2.2"

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -5,6 +5,15 @@ import logging
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+def sub_dict(d_list, keys):
+    new_metas = []
+    for meta in d_list:
+        tmp = {
+            k: meta[k] for k in keys
+        }
+        new_metas.append(tmp)
+    return new_metas
+
 class ObVecJsonTableTest(unittest.TestCase):
     def setUp(self) -> None:
         self.common_client = ObVecClient()
@@ -13,14 +22,16 @@ class ObVecJsonTableTest(unittest.TestCase):
         self.client = ObVecJsonTableClient(user_id=1)
     
     def test_create_and_alter_jtable(self):
+        self.client._reset()
+        keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
         self.client.perform_json_table_sql(
             "create table `t2` (c1 int NOT NULL DEFAULT 10, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2));"
         )
         tmp_client = ObVecJsonTableClient(user_id=1)
-        self.assertEqual(tmp_client.jmetadata.meta_cache['t2'], 
+        self.assertEqual(sub_dict(tmp_client.jmetadata.meta_cache['t2'], keys_to_check), 
             [
                 {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
-                {'jcol_id': 17, 'jcol_name': 'c2', 'jcol_type': 'VARCHAR(30)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'ca'}, 
+                {'jcol_id': 17, 'jcol_name': 'c2', 'jcol_type': 'VARCHAR(30)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'ca'"}, 
                 {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None}, 
                 {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None}
             ]
@@ -29,7 +40,7 @@ class ObVecJsonTableTest(unittest.TestCase):
         self.client.perform_json_table_sql(
             "ALTER TABLE t2 CHANGE COLUMN c2 changed_col INT"
         )
-        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t2'], keys_to_check),
             [
                 {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
                 {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
@@ -41,7 +52,7 @@ class ObVecJsonTableTest(unittest.TestCase):
         self.client.perform_json_table_sql(
             "ALTER TABLE t2 DROP c3"
         )
-        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t2'], keys_to_check),
             [
                 {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
                 {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
@@ -52,24 +63,24 @@ class ObVecJsonTableTest(unittest.TestCase):
         self.client.perform_json_table_sql(
             "ALTER TABLE t2 ADD COLUMN email VARCHAR(100) default 'example@example.com'"
         )
-        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t2'], keys_to_check),
             [
                 {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
                 {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
                 {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
-                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'example@example.com'}
+                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'example@example.com'"}
             ]
         )
 
         self.client.perform_json_table_sql(
             "ALTER TABLE t2 MODIFY COLUMN c4 INT NOT NULL DEFAULT 100"
         )
-        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t2'], keys_to_check),
             [
                 {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
                 {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
                 {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '100'},
-                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'example@example.com'}
+                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'example@example.com'"}
             ]
         )
 
@@ -77,11 +88,68 @@ class ObVecJsonTableTest(unittest.TestCase):
             "ALTER TABLE t2 RENAME TO alter_test"
         )
         self.assertEqual(self.client.jmetadata.meta_cache.get('t2', []), [])
-        self.assertEqual(self.client.jmetadata.meta_cache['alter_test'],
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['alter_test'], keys_to_check),
             [
                 {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
                 {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
                 {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '100'},
-                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'example@example.com'}
+                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'example@example.com'"}
+            ]
+        )
+
+    def test_create_and_alter_jtable_evil(self):
+        self.client._reset()
+        keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
+        self.client.perform_json_table_sql(
+            "create table `t1` (c1 int DEFAULT NULL, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2), c5 TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"
+        )
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t1'], keys_to_check), 
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 17, 'jcol_name': 'c2', 'jcol_type': 'VARCHAR(30)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'ca'"},
+                {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 20, 'jcol_name': 'c5', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t1 CHANGE COLUMN c2 changed_col DECIMAL"
+        )
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t1'], keys_to_check),
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'DECIMAL', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 20, 'jcol_name': 'c5', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t1 ADD COLUMN date timestamp default current_timestamp"
+        )
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t1'], keys_to_check),
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'DECIMAL', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 20, 'jcol_name': 'c5', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'},
+                {'jcol_id': 21, 'jcol_name': 'date', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t1 MODIFY COLUMN c4 INT DEFAULT NULL"
+        )
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t1'], keys_to_check),
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'DECIMAL', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 20, 'jcol_name': 'c5', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'},
+                {'jcol_id': 21, 'jcol_name': 'date', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'}
             ]
         )

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -16,9 +16,6 @@ def sub_dict(d_list, keys):
 
 class ObVecJsonTableTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.common_client = ObVecClient()
-        self.common_client.perform_raw_text_sql("TRUNCATE TABLE _data_json_t")
-        self.common_client.perform_raw_text_sql("TRUNCATE TABLE _meta_json_t")
         self.client = ObVecJsonTableClient(user_id=1)
     
     def test_create_and_alter_jtable(self):

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -1,4 +1,6 @@
 import unittest
+import datetime
+from decimal import Decimal
 from pyobvector import *
 import logging
 
@@ -13,6 +15,12 @@ def sub_dict(d_list, keys):
         }
         new_metas.append(tmp)
     return new_metas
+
+def get_all_rows(res):
+    rows = []
+    for r in res:
+        rows.append(r)
+    return rows
 
 class ObVecJsonTableTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -151,11 +159,11 @@ class ObVecJsonTableTest(unittest.TestCase):
             ]
         )
     
-    def test_insert(self):
+    def test_dml(self):
         self.client._reset()
         keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
         self.client.perform_json_table_sql(
-            "create table `t1` (c1 int DEFAULT NULL, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2), c5 TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"
+            "create table `t1` (c1 int DEFAULT NULL, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2), c5 TIMESTAMP DEFAULT '2024-12-30T03:35:30');"
         )
         self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t1'], keys_to_check), 
             [
@@ -163,7 +171,7 @@ class ObVecJsonTableTest(unittest.TestCase):
                 {'jcol_id': 17, 'jcol_name': 'c2', 'jcol_type': 'VARCHAR(30)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'ca'"},
                 {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None},
                 {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
-                {'jcol_id': 20, 'jcol_name': 'c5', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'}
+                {'jcol_id': 20, 'jcol_name': 'c5', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'2024-12-30T03:35:30'"}
             ]
         )
 
@@ -171,29 +179,132 @@ class ObVecJsonTableTest(unittest.TestCase):
             "insert into t1 (c2, c3) values ('hello', 'foo'), ('world', 'bar')"
         )
         self.client.perform_json_table_sql(
-            "insert into t1 values (1+2, 'baz', 'oceanbase', 12.3+45.6, CURRENT_TIMESTAMP)"
+            "insert into t1 values (1+2, 'baz', 'oceanbase', 12.3+45.6, '2024-12-30T06:56:00')"
+        )
+        res = self.client.perform_json_table_sql(
+            "select * from t1"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (None, 'hello', 'foo', None, datetime.datetime(2024, 12, 30, 3, 35, 30)),
+                (None, 'world', 'bar', None, datetime.datetime(2024, 12, 30, 3, 35, 30)),
+                (3, 'baz', 'oceanbase', Decimal('57.89'), datetime.datetime(2024, 12, 30, 6, 56)),
+            ]
         )
 
         self.client.perform_json_table_sql(
             "update t1 set c1=10+10, c2='updated' where c3='oceanbase'"
         )
+        res = self.client.perform_json_table_sql(
+            "select * from t1"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (None, 'hello', 'foo', None, datetime.datetime(2024, 12, 30, 3, 35, 30)),
+                (None, 'world', 'bar', None, datetime.datetime(2024, 12, 30, 3, 35, 30)),
+                (20, 'updated', 'oceanbase', Decimal('57.89'), datetime.datetime(2024, 12, 30, 6, 56)),
+            ]
+        )
 
         self.client.perform_json_table_sql(
             "delete from t1 where c1 is NULL"
+        )
+        res = self.client.perform_json_table_sql(
+            "select * from t1"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (20, 'updated', 'oceanbase', Decimal('57.89'), datetime.datetime(2024, 12, 30, 6, 56)),
+            ]
         )
 
         self.client.perform_json_table_sql(
             "select c1, c2, t1.c3 from t1 where c1 > 21"
         )
+        self.assertEqual(get_all_rows(res), [])
+
         self.client.perform_json_table_sql(
             "alter table t1 drop column c3"
         )
-        self.client.perform_json_table_sql(
-            "alter table t1 add column new_col TIMESTAMP default CURRENT_TIMESTAMP"
+        res = self.client.perform_json_table_sql(
+            "select * from t1"
         )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (20, 'updated', Decimal('57.89'), datetime.datetime(2024, 12, 30, 6, 56)),
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "alter table t1 add column new_col TIMESTAMP default '2024-12-30T02:44:17'"
+        )
+        res = self.client.perform_json_table_sql(
+            "select * from t1"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (20, 'updated', Decimal('57.89'), 
+                 datetime.datetime(2024, 12, 30, 6, 56),
+                 datetime.datetime(2024, 12, 30, 2, 44, 17)),
+            ]
+        )
+
         self.client.perform_json_table_sql(
             "alter table t1 modify column c4 INT DEFAULT 10"
         )
+        res = self.client.perform_json_table_sql(
+            "select * from t1"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (20, 'updated', 58, 
+                 datetime.datetime(2024, 12, 30, 6, 56),
+                 datetime.datetime(2024, 12, 30, 2, 44, 17)),
+            ]
+        )
+
         self.client.perform_json_table_sql(
             "alter table t1 change column c1 change_col DECIMAL(10,2)"
+        )
+        res = self.client.perform_json_table_sql(
+            "select * from t1"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (20.00, 'updated', 58, 
+                 datetime.datetime(2024, 12, 30, 6, 56),
+                 datetime.datetime(2024, 12, 30, 2, 44, 17)),
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "insert into t1 (change_col, c2, c4) values (12, 'pyobvector is good', 50), (90, 'oceanbase is good', 20)"
+        )
+        res = self.client.perform_json_table_sql(
+            "select sum(c4) as c4_sum from t1 where CHAR_LENGTH(c2) > 10"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (Decimal('70'),),
+            ]
+        )
+
+        res = self.client.perform_json_table_sql(
+            "select * from t1 where CHAR_LENGTH(c2) > 10 or c4 > 50 order by c4"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                (Decimal('90.00'), 'oceanbase is good', 20, datetime.datetime(2024, 12, 30, 3, 35, 30), datetime.datetime(2024, 12, 30, 2, 44, 17)),
+                (Decimal('12.00'), 'pyobvector is good', 50, datetime.datetime(2024, 12, 30, 3, 35, 30), datetime.datetime(2024, 12, 30, 2, 44, 17)),
+                (Decimal('20.00'), 'updated', 58, datetime.datetime(2024, 12, 30, 6, 56), datetime.datetime(2024, 12, 30, 2, 44, 17))
+            ]
         )

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -188,3 +188,15 @@ class ObVecJsonTableTest(unittest.TestCase):
         self.client.perform_json_table_sql(
             "select c1, c2, t1.c3 from t1 where c1 > 21"
         )
+        self.client.perform_json_table_sql(
+            "alter table t1 drop column c3"
+        )
+        self.client.perform_json_table_sql(
+            "alter table t1 add column new_col TIMESTAMP default CURRENT_TIMESTAMP"
+        )
+        self.client.perform_json_table_sql(
+            "alter table t1 modify column c4 INT DEFAULT 10"
+        )
+        self.client.perform_json_table_sql(
+            "alter table t1 change column c1 change_col DECIMAL(10,2)"
+        )

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -24,10 +24,12 @@ def get_all_rows(res):
 
 class ObVecJsonTableTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.client = ObVecJsonTableClient(user_id=1)
+        self.root_client = ObVecJsonTableClient(user_id=0)
+        self.client = ObVecJsonTableClient(user_id=1, user="jtuser@test")
     
     def test_create_and_alter_jtable(self):
-        self.client._reset()
+        self.root_client._reset()
+        self.client.refresh_metadata()
         keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
         self.client.perform_json_table_sql(
             "create table `t2` (c1 int NOT NULL DEFAULT 10, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2));"
@@ -103,7 +105,8 @@ class ObVecJsonTableTest(unittest.TestCase):
         )
 
     def test_create_and_alter_jtable_evil(self):
-        self.client._reset()
+        self.root_client._reset()
+        self.client.refresh_metadata()
         keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
         self.client.perform_json_table_sql(
             "create table `t1` (c1 int DEFAULT NULL, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2), c5 TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"
@@ -160,7 +163,8 @@ class ObVecJsonTableTest(unittest.TestCase):
         )
     
     def test_dml(self):
-        self.client._reset()
+        self.root_client._reset()
+        self.client.refresh_metadata()
         keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
         self.client.perform_json_table_sql(
             "create table `t1` (c1 int DEFAULT NULL, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2), c5 TIMESTAMP DEFAULT '2024-12-30T03:35:30');"

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -1,0 +1,87 @@
+import unittest
+from pyobvector import *
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class ObVecJsonTableTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.common_client = ObVecClient()
+        self.common_client.perform_raw_text_sql("TRUNCATE TABLE _data_json_t")
+        self.common_client.perform_raw_text_sql("TRUNCATE TABLE _meta_json_t")
+        self.client = ObVecJsonTableClient(user_id=1)
+    
+    def test_create_and_alter_jtable(self):
+        self.client.perform_json_table_sql(
+            "create table `t2` (c1 int NOT NULL DEFAULT 10, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2));"
+        )
+        tmp_client = ObVecJsonTableClient(user_id=1)
+        self.assertEqual(tmp_client.jmetadata.meta_cache['t2'], 
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
+                {'jcol_id': 17, 'jcol_name': 'c2', 'jcol_type': 'VARCHAR(30)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'ca'}, 
+                {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None}, 
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t2 CHANGE COLUMN c2 changed_col INT"
+        )
+        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
+                {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None}, 
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t2 DROP c3"
+        )
+        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t2 ADD COLUMN email VARCHAR(100) default 'example@example.com'"
+        )
+        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'example@example.com'}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t2 MODIFY COLUMN c4 INT NOT NULL DEFAULT 100"
+        )
+        self.assertEqual(self.client.jmetadata.meta_cache['t2'],
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '100'},
+                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'example@example.com'}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "ALTER TABLE t2 RENAME TO alter_test"
+        )
+        self.assertEqual(self.client.jmetadata.meta_cache.get('t2', []), [])
+        self.assertEqual(self.client.jmetadata.meta_cache['alter_test'],
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
+                {'jcol_id': 17, 'jcol_name': 'changed_col', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None}, 
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '100'},
+                {'jcol_id': 20, 'jcol_name': 'email', 'jcol_type': 'VARCHAR(100)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'example@example.com'}
+            ]
+        )

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -153,3 +153,38 @@ class ObVecJsonTableTest(unittest.TestCase):
                 {'jcol_id': 21, 'jcol_name': 'date', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'}
             ]
         )
+    
+    def test_insert(self):
+        self.client._reset()
+        keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
+        self.client.perform_json_table_sql(
+            "create table `t1` (c1 int DEFAULT NULL, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2), c5 TIMESTAMP DEFAULT CURRENT_TIMESTAMP);"
+        )
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['t1'], keys_to_check), 
+            [
+                {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': None},
+                {'jcol_id': 17, 'jcol_name': 'c2', 'jcol_type': 'VARCHAR(30)', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': "'ca'"},
+                {'jcol_id': 18, 'jcol_name': 'c3', 'jcol_type': 'VARCHAR', 'jcol_nullable': False, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 19, 'jcol_name': 'c4', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 20, 'jcol_name': 'c5', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': True, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'}
+            ]
+        )
+
+        self.client.perform_json_table_sql(
+            "insert into t1 (c2, c3) values ('hello', 'foo'), ('world', 'bar')"
+        )
+        self.client.perform_json_table_sql(
+            "insert into t1 values (1+2, 'baz', 'oceanbase', 12.3+45.6, CURRENT_TIMESTAMP)"
+        )
+
+        self.client.perform_json_table_sql(
+            "update t1 set c1=10+10, c2='updated' where c3='oceanbase'"
+        )
+
+        self.client.perform_json_table_sql(
+            "delete from t1 where c1 is NULL"
+        )
+
+        self.client.perform_json_table_sql(
+            "select c1, c2, t1.c3 from t1 where c1 > 21"
+        )

--- a/tests/test_oceanbase_dialect.py
+++ b/tests/test_oceanbase_dialect.py
@@ -1,0 +1,43 @@
+import unittest
+from pyobvector import *
+import logging
+
+from sqlglot import parse_one
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+class OceanBaseDialectTest(unittest.TestCase):
+    def setUp(self) -> None:
+        return super().setUp()
+    
+    def test_drop_column(self):
+        sql = "ALTER TABLE users DROP COLUMN age"
+        ob_ast = parse_one(sql, dialect="oceanbase")
+        logger.info(f"\n{repr(ob_ast)}")
+
+        sql = "ALTER TABLE users DROP age"
+        ob_ast = parse_one(sql, dialect="oceanbase")
+        logger.info(f"\n{repr(ob_ast)}")
+
+    def test_modify_column(self):
+        sql = "ALTER TABLE users MODIFY COLUMN email VARCHAR(100) NOT NULL"
+        ob_ast = parse_one(sql, dialect="oceanbase")
+        logger.info(f"\n{repr(ob_ast)}")
+
+        sql = "ALTER TABLE users MODIFY email VARCHAR(100) NOT NULL"
+        ob_ast = parse_one(sql, dialect="oceanbase")
+        logger.info(f"\n{repr(ob_ast)}")
+
+        sql = "ALTER TABLE users MODIFY COLUMN email VARCHAR(100) NOT NULL DEFAULT 'ca'"
+        ob_ast = parse_one(sql, dialect="oceanbase")
+        logger.info(f"\n{repr(ob_ast)}")
+
+    def test_change_column(self):
+        sql = "ALTER TABLE users CHANGE COLUMN username user_name VARCHAR(50)"
+        ob_ast = parse_one(sql, dialect="oceanbase")
+        logger.info(f"\n{repr(ob_ast)}")
+
+        sql = "ALTER TABLE users CHANGE username user_name VARCHAR(50)"
+        ob_ast = parse_one(sql, dialect="oceanbase")
+        logger.info(f"\n{repr(ob_ast)}")


### PR DESCRIPTION
## Summary
- Support DDL/DML for JSON TABLE

1. ALTER TABLE XXX CHANGE XXX
2. ALTER  TABLE XXX MODIFY XXX
3. ALTER TABLE XXX ADD XXX
4. ALTER TABLE XXX DROP XXX
5. CREATE TABLE XXX
6. INSERT INTO XXX
7. UPDATE XXX SET XXX WHERE XXX
8. DELETE FROM XXX WHERE XXX
9. SELECT XXX  FROM XXX WHERE XXX

- DataTypes supported by JSON TABLE

1. BOOL
2. TIMESTAMP
3. VARCHAR
4. DECIMAL
5. INT

- testsuites:

1. tests/test_json_table.py
2. tests/test_oceanbase_dialect.py

## Solution Description
introduce `sqlglot` & `pydantic` into pyobvector
