### PR TITLE
Support JSON Table Online Basic Cases

### DIFF
--- a/pyobvector/client/ob_vec_json_table_client.py
+++ b/pyobvector/client/ob_vec_json_table_client.py
@@ -6,7 +6,9 @@ from typing import Dict, List, Optional, Any
 from sqlalchemy import Column, Integer, String, JSON, Engine, select, text, func, CursorResult
 from sqlalchemy.dialects.mysql import TINYINT
 from sqlalchemy.orm import declarative_base, sessionmaker, Session
-from sqlglot import parse_one, exp, Expression
+from sqlglot import parse_one, exp, Expression, to_identifier
+from sqlglot.expressions import Concat
+
 
 from .ob_vec_client import ObVecClient
 from ..json_table import (
@@ -35,7 +37,7 @@ class ObVecJsonTableClient(ObVecClient):
     class JsonTableMetaTBL(Base):
         __tablename__ = JSON_TABLE_META_TABLE_NAME
         
-        user_id = Column(Integer, primary_key=True)
+        user_id = Column(String(128), primary_key=True, autoincrement=False)
         jtable_name = Column(String(512), primary_key=True)
         jcol_id = Column(Integer, primary_key=True)
         jcol_name = Column(String(512), primary_key=True)
@@ -47,13 +49,13 @@ class ObVecJsonTableClient(ObVecClient):
     class JsonTableDataTBL(Base):
         __tablename__ = JSON_TABLE_DATA_TABLE_NAME
 
-        user_id = Column(Integer, primary_key=True)
+        user_id = Column(String(128), primary_key=True, autoincrement=False)
         jtable_name = Column(String(512), primary_key=True)
         jdata_id = Column(Integer, primary_key=True, autoincrement=True, nullable=False)
         jdata = Column(JSON)
 
     class JsonTableMetadata:
-        def __init__(self, user_id: int):
+        def __init__(self, user_id: str):
             self.user_id = user_id
             self.meta_cache: Dict[str, List] = {}
 
@@ -78,7 +80,7 @@ class ObVecJsonTableClient(ObVecClient):
                 if col_type == 'DECIMAL':
                     factory = JsonTableDecimalFactory(10, 0)
                 else:
-                    decimal_pattern = r'DECIMAL\((\d+),\s*(\d+)\)'
+                    decimal_pattern = r'DECIMAL\s*\((\d+),\s*(\d+)\)'
                     decimal_matches = re.findall(decimal_pattern, col_type)
                     x, y = decimal_matches[0]
                     factory = JsonTableDecimalFactory(int(x), int(y))
@@ -119,7 +121,7 @@ class ObVecJsonTableClient(ObVecClient):
 
     def __init__(
         self,
-        user_id: int,
+        user_id: str,
         uri: str = "127.0.0.1:2881",
         user: str = "root@test",
         password: str = "",
@@ -238,7 +240,9 @@ class ObVecJsonTableClient(ObVecClient):
                 elif isinstance(cons.kind, exp.NotNullColumnConstraint):
                     col_nullable = False
                 else:
-                    raise ValueError(f"{cons.kind} constriaint is not supported.")
+                    pass
+                    # raise ValueError(f"{cons.kind} constriaint is not supported.")
+                    # TODO support json index
             
             if col_has_default and (col_default_val is not None):
                 # check default value is valid
@@ -689,6 +693,20 @@ class ObVecJsonTableClient(ObVecClient):
             if not self._check_col_exists(table_name, col_name):
                 raise ValueError(f"Column {col_name} does not exists")
             col_expr = expr.expression
+            new_node = parse_one(f"JSON_VALUE({JSON_TABLE_DATA_TABLE_NAME}.jdata, '$.{col_name}')")
+            for column in col_expr.find_all(exp.Column):
+                parent_node = column.parent
+                if isinstance(parent_node.args[column.arg_key], list):
+                    new_expr_list = []
+                    for node in parent_node.args[column.arg_key]:
+                        if isinstance(node, exp.Column):
+                            new_expr_list.append(new_node)
+                        else:
+                            new_expr_list.append(node)
+                    parent_node.args[column.arg_key] = new_expr_list
+                elif isinstance(parent_node.args[column.arg_key], exp.Column):
+                    parent_node.args[column.arg_key] = new_node
+            logger.info(str(col_expr))
             path_settings.append(f"'$.{col_name}', {str(col_expr)}")
 
         where_clause = None        
@@ -700,7 +718,7 @@ class ObVecJsonTableClient(ObVecClient):
                 column.parent.args['this'] = parse_one(
                     f"JSON_VALUE({JSON_TABLE_DATA_TABLE_NAME}.jdata, '$.{where_col_name}')"
                 )
-            where_clause = f"{JSON_TABLE_DATA_TABLE_NAME}.user_id = {self.user_id} AND {JSON_TABLE_DATA_TABLE_NAME}.jtable_name = '{table_name}' AND ({str(ast.args['where'].this)})"
+            where_clause = f"{JSON_TABLE_DATA_TABLE_NAME}.user_id = '{self.user_id}' AND {JSON_TABLE_DATA_TABLE_NAME}.jtable_name = '{table_name}' AND ({str(ast.args['where'].this)})"
         
         if where_clause:
             update_sql = f"UPDATE {JSON_TABLE_DATA_TABLE_NAME} SET jdata = JSON_REPLACE({JSON_TABLE_DATA_TABLE_NAME}.jdata, {', '.join(path_settings)}) WHERE {where_clause}"
@@ -724,7 +742,7 @@ class ObVecJsonTableClient(ObVecClient):
                 column.parent.args['this'] = parse_one(
                     f"JSON_VALUE({JSON_TABLE_DATA_TABLE_NAME}.jdata, '$.{where_col_name}')"
                 )
-            where_clause = f"{JSON_TABLE_DATA_TABLE_NAME}.user_id = {self.user_id} AND {JSON_TABLE_DATA_TABLE_NAME}.jtable_name = '{table_name}' AND ({str(ast.args['where'].this)})"
+            where_clause = f"{JSON_TABLE_DATA_TABLE_NAME}.user_id = '{self.user_id}' AND {JSON_TABLE_DATA_TABLE_NAME}.jtable_name = '{table_name}' AND ({str(ast.args['where'].this)})"
         
         if where_clause:
             delete_sql = f"DELETE FROM {JSON_TABLE_DATA_TABLE_NAME} WHERE {where_clause}"
@@ -746,7 +764,7 @@ class ObVecJsonTableClient(ObVecClient):
         if not self._check_table_exists(table_name):
             raise ValueError(f"Table {table_name} does not exists")
         
-        ast.args['from'].args['this'].args['this'].args['this'] = JSON_TABLE_DATA_TABLE_NAME
+        ast.args['from'].args['this'].args['this'] = to_identifier(name=JSON_TABLE_DATA_TABLE_NAME, quoted=False)
 
         col_meta = self.jmetadata.meta_cache[table_name]
         json_table_meta_str = []
@@ -794,7 +812,7 @@ class ObVecJsonTableClient(ObVecClient):
         else:
             ast.args['joins'] = [join_node]
 
-        extra_filter_str = f"{JSON_TABLE_DATA_TABLE_NAME}.user_id = {self.user_id} AND {JSON_TABLE_DATA_TABLE_NAME}.jtable_name = '{table_name}'"
+        extra_filter_str = f"{JSON_TABLE_DATA_TABLE_NAME}.user_id = '{self.user_id}' AND {JSON_TABLE_DATA_TABLE_NAME}.jtable_name = '{table_name}'"
         if 'where' in ast.args.keys():
             filter_str = str(ast.args['where'].args['this'])
             new_filter_str = f"{extra_filter_str} AND ({filter_str})"

--- a/tests/test_json_table.py
+++ b/tests/test_json_table.py
@@ -24,8 +24,8 @@ def get_all_rows(res):
 
 class ObVecJsonTableTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.root_client = ObVecJsonTableClient(user_id=0)
-        self.client = ObVecJsonTableClient(user_id=1, user="jtuser@test")
+        self.root_client = ObVecJsonTableClient(user_id='0')
+        self.client = ObVecJsonTableClient(user_id='e5a69db04c5ea54adf324907d4b8f364', user="jtuser@test")
     
     def test_create_and_alter_jtable(self):
         self.root_client._reset()
@@ -34,7 +34,7 @@ class ObVecJsonTableTest(unittest.TestCase):
         self.client.perform_json_table_sql(
             "create table `t2` (c1 int NOT NULL DEFAULT 10, c2 varchar(30) DEFAULT 'ca', c3 varchar not null, c4 decimal(10, 2));"
         )
-        tmp_client = ObVecJsonTableClient(user_id=1)
+        tmp_client = ObVecJsonTableClient(user_id='e5a69db04c5ea54adf324907d4b8f364')
         self.assertEqual(sub_dict(tmp_client.jmetadata.meta_cache['t2'], keys_to_check), 
             [
                 {'jcol_id': 16, 'jcol_name': 'c1', 'jcol_type': 'INT', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': '10'}, 
@@ -363,4 +363,102 @@ class ObVecJsonTableTest(unittest.TestCase):
                 (15, 'alice'),
                 (2, 'bob'),
             ]
+        )
+
+    def test_timestamp_datatype(self):
+        self.root_client._reset()
+        self.client.refresh_metadata()
+        self.client.perform_json_table_sql(
+            "create table `t1` (c1 int DEFAULT NULL, c2 TIMESTAMP);"
+        )
+
+        self.client.perform_json_table_sql(
+            "insert into t1 values (1, CURRENT_DATE - INTERVAL '1' MONTH);"
+        )
+
+        self.client.perform_json_table_sql(
+            "select * from t1"
+        )
+
+    def test_online_cases(self):
+        self.root_client._reset()
+        self.client.refresh_metadata()
+        keys_to_check = ['jcol_id', 'jcol_name', 'jcol_type', 'jcol_nullable', 'jcol_has_default', 'jcol_default']
+        self.client.perform_json_table_sql(
+            "CREATE TABLE `table_unit_test`(id INT, field0 VARCHAR(1024), field1 INT, field2 DECIMAL(10,2), field3 timestamp NOT NULL default CURRENT_TIMESTAMP, field4 varchar(1024));"
+        )
+        logger.info(sub_dict(self.client.jmetadata.meta_cache['table_unit_test'], keys_to_check))
+        self.assertEqual(sub_dict(self.client.jmetadata.meta_cache['table_unit_test'], keys_to_check), 
+            [
+                {'jcol_id': 16, 'jcol_name': 'id', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 17, 'jcol_name': 'field0', 'jcol_type': 'VARCHAR(1024)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 18, 'jcol_name': 'field1', 'jcol_type': 'INT', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 19, 'jcol_name': 'field2', 'jcol_type': 'DECIMAL(10,2)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+                {'jcol_id': 20, 'jcol_name': 'field3', 'jcol_type': 'TIMESTAMP', 'jcol_nullable': False, 'jcol_has_default': True, 'jcol_default': 'CURRENT_TIMESTAMP()'},
+                {'jcol_id': 21, 'jcol_name': 'field4', 'jcol_type': 'VARCHAR(1024)', 'jcol_nullable': True, 'jcol_has_default': False, 'jcol_default': None},
+            ]
+        )
+        self.client.perform_json_table_sql(
+            "INSERT INTO `table_unit_test` (id, field0, field1, field2, field4) VALUES (1, '汽车保养', 1, 1000.00, '4S 店')"
+        )
+        self.client.perform_json_table_sql(
+            "INSERT INTO `table_unit_test` (id, field0, field1, field2, field3, field4) VALUES (2, '奶茶', 2, 15.00, CURRENT_TIMESTAMP(), '商场'), (3, '书', 2, 40.00, NOW() - INTERVAL '1' DAY, '商场'), (4, '手机', 2, 6000.00, '2025-03-09', '商场')"
+        )
+
+        res = self.client.perform_json_table_sql(
+            "SELECT field0 AS 消费内容, field1 AS 消费类型, field2 AS 消费金额, field4 AS 消费地点 FROM `table_unit_test` LIMIT 2"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [
+                ('汽车保养', 1, Decimal('1000.00'), '4S 店'),
+                ('奶茶', 2, Decimal('15.00'), '商场')
+            ]
+        )
+
+        res = self.client.perform_json_table_sql(
+            "SELECT field2 FROM `table_unit_test` WHERE field0 like '%汽车%' AND field4 like '%店%' ORDER BY field2 DESC LIMIT 2"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [(Decimal('1000.00'),)]
+        )
+
+        res = self.client.perform_json_table_sql(
+            "SELECT field0, field1, field2 FROM `table_unit_test` WHERE DATE(field3)='2025-03-09' ORDER BY field2 DESC LIMIT 2"
+        )
+        # logger.info(get_all_rows(res))
+        self.assertEqual(
+            get_all_rows(res),
+            [('手机', 2, Decimal('6000.00'))]
+        )
+
+        res = self.client.perform_json_table_sql(
+            "SELECT field0, field1, field2, field3 FROM `table_unit_test` WHERE field4 like '%商场%' AND field3 <= CAST('2025-03-10' AS DATE) LIMIT 20"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [('手机', 2, Decimal('6000.00'), datetime.datetime(2025, 3, 9, 0, 0))]
+        )
+
+        self.client.perform_json_table_sql(
+            "UPDATE `table_unit_test` SET field3 = '2025-03-14' WHERE field0 = '汽车保养'"
+        )
+        res = self.client.perform_json_table_sql(
+            "SELECT field0, field1, field2, field3 FROM `table_unit_test` WHERE DATE(field3) = '2025-03-14' AND field0 = '汽车保养'"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [('汽车保养', 1, Decimal('1000.00'), datetime.datetime(2025, 3, 14, 0, 0))]
+        )
+
+        self.client.perform_json_table_sql(
+            "UPDATE `table_unit_test` SET field0 = CONCAT(field0, '代办') WHERE DATE(field3) = '2025-03-14'"
+        )
+        res = self.client.perform_json_table_sql(
+            "SELECT field0, field1, field2, field3 FROM `table_unit_test` WHERE DATE(field3) = '2025-03-14'"
+        )
+        self.assertEqual(
+            get_all_rows(res),
+            [('汽车保养代办', 1, Decimal('1000.00'), datetime.datetime(2025, 3, 14, 0, 0))]
         )


### PR DESCRIPTION
## Summary
1. Fix Quoted Identifier in select statement.
2. Support complex expressions in update statement, for example, 'UPDATE `table_unit_test` SET field0 = CONCAT(field0, '代办') WHERE DATE(field3) = '2025-03-14''
3. Add test cases.