### PR TITLE
security: bump aiomysql to 0.3.2 to resolve CVE-2025-62611

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ python = ">=3.9,<4.0"
 numpy = ">=1.17.0,<2.0.0"
 sqlalchemy = ">=1.4,<=3"
 pymysql = "^1.1.1"
-aiomysql = "^0.2.0"
+aiomysql = "^0.3.2"
 sqlglot = "^26.0.1"
 pydantic = ">=2.7.0,<3"
 


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
security: bump aiomysql to 0.3.2 to resolve CVE-2025-62611
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->



## Solution Description
<!-- Please clearly and concisely describe your solution. -->

 - Update `pyproject.toml:13` to require `aiomysql ^0.3.2`, addressing CVE-2025-62611.
  - Run `poetry update aiomysql` so `poetry.lock` and the environment resolve to `aiomysql 0.3.2` (`poetry show aiomysql ` confirms).
  - Verification: with OceanBase running and an empty-password `jtuser@test` user created, `poetry run pytest `passes except for `tests/test_json_table.py::ObVecJsonTableTest::test_user_group`, which still
    fails because the multi-user scenario can’t find `table table_shared`.

