### PR TITLE
feat: add SeekDB version check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
-numpy = ">=1.17.0,<2.0.0"
+numpy = ">=1.17.0"
 sqlalchemy = ">=1.4,<=3"
 pymysql = "^1.1.1"
 aiomysql = "^0.3.2"


### PR DESCRIPTION
- Add version check for SeekDB (4.3.5.3) in hybrid_search.py
- Allow hybrid search on SeekDB version 4.3.5.3

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

add hybrid search documentation and SeekDB version check

Close #38 

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
