### PR TITLE
fix: handle None server_version_info in get_isolation_level to preven…

### DIFF
--- a/pyobvector/client/hybrid_search.py
+++ b/pyobvector/client/hybrid_search.py
@@ -30,13 +30,9 @@ class HybridSearch(Client):
         
         if self.ob_version < min_required_version:
             # For versions < 4.4.1.0, check if it's SeekDB
-            with self.engine.connect() as conn:
-                with conn.begin():
-                    res = conn.execute(text("SELECT version()"))
-                    version_str = [r[0] for r in res][0]
-                    if "SeekDB" in version_str:
-                        logger.info(f"SeekDB detected in version string: {version_str}, allowing hybrid search")
-                        return
+            if self._is_seekdb():
+                logger.info("SeekDB detected, allowing hybrid search")
+                return
             raise ClusterVersionException(
                 code=ErrorCode.NOT_SUPPORTED,
                 message=ExceptionsMessage.ClusterVersionIsLow % ("Hybrid Search", "4.4.1.0"),

--- a/pyobvector/client/index_param.py
+++ b/pyobvector/client/index_param.py
@@ -134,8 +134,11 @@ class IndexParam:
                 if 'efSearch' in params:
                     ob_params['ef_search'] = params['efSearch']
         
-        if self.is_index_type_sparse_vector() and ob_params['distance'] != 'inner_product':
-            raise ValueError("Metric type should be 'inner_product' for sparse vector index.")
+        if self.is_index_type_sparse_vector():
+            if ob_params['distance'] != 'inner_product':
+                raise ValueError("Metric type should be 'inner_product' for sparse vector index.")
+            if 'sparse_index_type' in self.kwargs:
+                ob_params['type'] = self.kwargs['sparse_index_type']
         return ob_params
 
     def param_str(self):

--- a/pyobvector/client/ob_vec_client.py
+++ b/pyobvector/client/ob_vec_client.py
@@ -99,7 +99,11 @@ class ObVecClient(ObClient):
                     create_table_sql = str(CreateTable(table).compile(self.engine))
                     new_sql = create_table_sql[:create_table_sql.rfind(')')]
                     for sparse_vidx in sparse_vidxs:
-                        new_sql += f",\n\tVECTOR INDEX {sparse_vidx.index_name}({sparse_vidx.field_name}) with (distance=inner_product)"
+                        sparse_params = sparse_vidx._parse_kwargs()
+                        if 'type' in sparse_params:
+                            new_sql += f",\n\tVECTOR INDEX {sparse_vidx.index_name}({sparse_vidx.field_name}) with (type={sparse_params['type']}, distance=inner_product)"
+                        else:
+                            new_sql += f",\n\tVECTOR INDEX {sparse_vidx.index_name}({sparse_vidx.field_name}) with (distance=inner_product)"
                     new_sql += "\n)"
                     conn.execute(text(new_sql))
                 else:

--- a/pyobvector/client/ob_vec_json_table_client.py
+++ b/pyobvector/client/ob_vec_json_table_client.py
@@ -817,11 +817,11 @@ class ObVecJsonTableClient(ObVecClient):
     ):
         real_user_id = opt_user_id or self.user_id
 
-        table_name = ast.args['from'].this.this.this
+        table_name = ast.args['from_'].this.this.this
         if not self._check_table_exists(table_name):
             raise ValueError(f"Table {table_name} does not exists")
         
-        ast.args['from'].args['this'].args['this'] = to_identifier(name=JSON_TABLE_DATA_TABLE_NAME, quoted=False)
+        ast.args['from_'].args['this'].args['this'] = to_identifier(name=JSON_TABLE_DATA_TABLE_NAME, quoted=False)
 
         col_meta = self.jmetadata.meta_cache[table_name]
         json_table_meta_str = []


### PR DESCRIPTION
…t TypeError

- Add _ensure_server_version_info helper function to initialize server_version_info
- Override get_isolation_level in OceanBaseDialect and AsyncOceanBaseDialect
- Add tests to verify the fix works correctly
- Fixes TypeError when isolation_level parameter is passed to create_engine

<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
handle None server_version_info in get_isolation_level to prevent TypeError
close #42 

## Solution Description
<!-- Please clearly and concisely describe your solution. -->
