### PR TITLE
fix: HybridSearch.search() crashes when OceanBase returns NULL for empty results

### DIFF
--- a/pyobvector/client/hybrid_search.py
+++ b/pyobvector/client/hybrid_search.py
@@ -61,6 +61,8 @@ class HybridSearch(Client):
         with self.engine.connect() as conn:
             with conn.begin():
                 res = conn.execute(sql, {"index": index, "body_str": body_str}).fetchone()
+                if res[0] is None:
+                    return []
                 return json.loads(res[0])
 
     def get_sql(
@@ -84,4 +86,6 @@ class HybridSearch(Client):
         with self.engine.connect() as conn:
             with conn.begin():
                 res = conn.execute(sql, {"index": index, "body_str": body_str}).fetchone()
+                if res[0] is None:
+                    return ""
                 return res[0]


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
fix #53 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->
