### PR TITLE
fix: make SeekDB version check case-insensitive

### DIFF
--- a/pyobvector/client/ob_client.py
+++ b/pyobvector/client/ob_client.py
@@ -110,7 +110,7 @@ class ObClient:
             with self.engine.connect() as conn:
                 result = conn.execute(text("SELECT VERSION()"))
                 version_str = [r[0] for r in result][0]
-                is_seekdb = "SeekDB" in version_str
+                is_seekdb = "seekdb" in version_str.lower()
                 self._is_seekdb_cached = is_seekdb
                 logger.debug(
                     f"Version query result: {version_str}, is_seekdb: {is_seekdb}"


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->
Close #57 


## Solution Description
<!-- Please clearly and concisely describe your solution. -->

The latest version of seekdb judges that lowercase is changed to lowercase, and you need to ignore the case