### PR TITLE
fix(seekdb): fix ann_search returning no rows in embedded mode

### DIFF
--- a/pyobvector/client/ob_client.py
+++ b/pyobvector/client/ob_client.py
@@ -161,7 +161,8 @@ class ObClient:
     def _flush_seekdb_index(self) -> None:
         """Flush async HNSW index builds in embedded seekdb after insert.
 
-        No-op when not using embedded seekdb or seekdb version < 1.3.0.
+        No-op when not using embedded seekdb or when the server does not expose
+        a ``refresh_index`` method.
         """
         server = self.engine.get_execution_options().get("seekdb_server")
         if server is not None and hasattr(server, "refresh_index"):

--- a/pyobvector/client/ob_client.py
+++ b/pyobvector/client/ob_client.py
@@ -163,9 +163,12 @@ class ObClient:
 
         No-op when not using embedded seekdb or seekdb version < 1.3.0.
         """
-        server = getattr(self.engine, "_seekdb_server", None)
+        server = self.engine.get_execution_options().get("seekdb_server")
         if server is not None and hasattr(server, "refresh_index"):
-            server.refresh_index()
+            try:
+                server.refresh_index()
+            except Exception as e:
+                logger.warning("seekdb index refresh failed after insert: %s", e)
 
     def _insert_partition_hint_for_query_sql(self, sql: str, partition_hint: str):
         from_index = sql.find("FROM")

--- a/pyobvector/client/ob_client.py
+++ b/pyobvector/client/ob_client.py
@@ -158,6 +158,15 @@ class ObClient:
             logger.warning(f"Failed to query version: {e}")
         return is_seekdb
 
+    def _flush_seekdb_index(self) -> None:
+        """Flush async HNSW index builds in embedded seekdb after insert.
+
+        No-op when not using embedded seekdb or seekdb version < 1.3.0.
+        """
+        server = getattr(self.engine, "_seekdb_server", None)
+        if server is not None and hasattr(server, "refresh_index"):
+            server.refresh_index()
+
     def _insert_partition_hint_for_query_sql(self, sql: str, partition_hint: str):
         from_index = sql.find("FROM")
         assert from_index != -1
@@ -282,6 +291,7 @@ class ObClient:
                         .with_hint(f"PARTITION({partition_name})")
                         .values(data)
                     )
+        self._flush_seekdb_index()
 
     def upsert(
         self,

--- a/pyobvector/client/ob_vec_client.py
+++ b/pyobvector/client/ob_vec_client.py
@@ -29,6 +29,55 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
 
+class _MappingsResult:
+    def __init__(self, rows: list, keys: list[str]) -> None:
+        self._data = [dict(zip(keys, row)) for row in rows]
+
+    def fetchall(self) -> list[dict]:
+        return list(self._data)
+
+    def all(self) -> list[dict]:
+        return list(self._data)
+
+    def __iter__(self):
+        return iter(self._data)
+
+
+class _BufferedResult:
+    """Buffers all rows from a CursorResult before the connection closes.
+
+    Returning conn.execute() directly from inside a ``with engine.connect()``
+    block hands the caller a dead cursor once the with-block exits.  This
+    wrapper fetches everything eagerly so the result stays valid.
+    """
+
+    def __init__(self, cursor_result) -> None:
+        self._rows: list = cursor_result.fetchall()
+        self._keys: list[str] = list(cursor_result.keys())
+
+    def fetchall(self) -> list:
+        rows, self._rows = self._rows, []
+        return rows
+
+    def fetchone(self):
+        if not self._rows:
+            return None
+        row, self._rows = self._rows[0], self._rows[1:]
+        return row
+
+    def __iter__(self):
+        return iter(self._rows)
+
+    def all(self) -> list:
+        return self.fetchall()
+
+    def keys(self) -> list[str]:
+        return self._keys
+
+    def mappings(self) -> "_MappingsResult":
+        return _MappingsResult(self._rows, self._keys)
+
+
 class ObVecClient(ObClient):
     """The OceanBase Vector Client"""
 
@@ -408,11 +457,11 @@ class ObVecClient(ObClient):
                     )
 
                 if partition_names is None:
-                    return conn.execute(text(stmt_str))
+                    return _BufferedResult(conn.execute(text(stmt_str)))
                 stmt_str = self._insert_partition_hint_for_query_sql(
                     stmt_str, f"PARTITION({', '.join(partition_names)})"
                 )
-                return conn.execute(text(stmt_str))
+                return _BufferedResult(conn.execute(text(stmt_str)))
 
     def post_ann_search(
         self,
@@ -487,7 +536,7 @@ class ObVecClient(ObClient):
                                 )
                             )
                         )
-                    return conn.execute(stmt)
+                    return _BufferedResult(conn.execute(stmt))
                 stmt_str = str(
                     stmt.compile(
                         dialect=self.engine.dialect,
@@ -499,7 +548,7 @@ class ObVecClient(ObClient):
                 )
                 if str_list is not None:
                     str_list.append(stmt_str)
-                return conn.execute(text(stmt_str))
+                return _BufferedResult(conn.execute(text(stmt_str)))
 
     def precise_search(
         self,
@@ -537,7 +586,7 @@ class ObVecClient(ObClient):
                 stmt = stmt.where(*where_clause)
             with self.engine.connect() as conn:
                 with conn.begin():
-                    return conn.execute(stmt)
+                    return _BufferedResult(conn.execute(stmt))
         else:
             stmt = (
                 select(table)
@@ -548,4 +597,4 @@ class ObVecClient(ObClient):
                 stmt = stmt.where(*where_clause)
             with self.engine.connect() as conn:
                 with conn.begin():
-                    return conn.execute(stmt)
+                    return _BufferedResult(conn.execute(stmt))

--- a/pyobvector/client/ob_vec_client.py
+++ b/pyobvector/client/ob_vec_client.py
@@ -1,7 +1,6 @@
 """OceanBase Vector Store Client."""
 
 import logging
-from collections.abc import Iterator
 from typing import Any
 
 import numpy as np
@@ -28,55 +27,6 @@ from ..util import ObVersion
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
-
-
-class _MappingsResult:
-    def __init__(self, rows: list, keys: list[str]) -> None:
-        self._data = [dict(zip(keys, row)) for row in rows]
-
-    def fetchall(self) -> list[dict]:
-        return list(self._data)
-
-    def all(self) -> list[dict]:
-        return list(self._data)
-
-    def __iter__(self) -> Iterator[dict]:
-        return iter(self._data)
-
-
-class _BufferedResult:
-    """Buffers all rows from a CursorResult before the connection closes.
-
-    Returning conn.execute() directly from inside a ``with engine.connect()``
-    block hands the caller a dead cursor once the with-block exits.  This
-    wrapper fetches everything eagerly so the result stays valid.
-    """
-
-    def __init__(self, cursor_result: Any) -> None:
-        self._rows: list[tuple] = cursor_result.fetchall()
-        self._keys: list[str] = list(cursor_result.keys())
-
-    def fetchall(self) -> list[tuple]:
-        rows, self._rows = self._rows, []
-        return rows
-
-    def fetchone(self) -> tuple | None:
-        if not self._rows:
-            return None
-        row, self._rows = self._rows[0], self._rows[1:]
-        return row
-
-    def __iter__(self) -> Iterator[tuple]:
-        return iter(self._rows)
-
-    def all(self) -> list[tuple]:
-        return self.fetchall()
-
-    def keys(self) -> list[str]:
-        return self._keys
-
-    def mappings(self) -> "_MappingsResult":
-        return _MappingsResult(self._rows, self._keys)
 
 
 class ObVecClient(ObClient):
@@ -458,11 +408,11 @@ class ObVecClient(ObClient):
                     )
 
                 if partition_names is None:
-                    return _BufferedResult(conn.execute(text(stmt_str)))
+                    return conn.execute(text(stmt_str)).freeze()()
                 stmt_str = self._insert_partition_hint_for_query_sql(
                     stmt_str, f"PARTITION({', '.join(partition_names)})"
                 )
-                return _BufferedResult(conn.execute(text(stmt_str)))
+                return conn.execute(text(stmt_str)).freeze()()
 
     def post_ann_search(
         self,
@@ -537,7 +487,7 @@ class ObVecClient(ObClient):
                                 )
                             )
                         )
-                    return _BufferedResult(conn.execute(stmt))
+                    return conn.execute(stmt).freeze()()
                 stmt_str = str(
                     stmt.compile(
                         dialect=self.engine.dialect,
@@ -549,7 +499,7 @@ class ObVecClient(ObClient):
                 )
                 if str_list is not None:
                     str_list.append(stmt_str)
-                return _BufferedResult(conn.execute(text(stmt_str)))
+                return conn.execute(text(stmt_str)).freeze()()
 
     def precise_search(
         self,
@@ -587,7 +537,7 @@ class ObVecClient(ObClient):
                 stmt = stmt.where(*where_clause)
             with self.engine.connect() as conn:
                 with conn.begin():
-                    return _BufferedResult(conn.execute(stmt))
+                    return conn.execute(stmt).freeze()()
         else:
             stmt = (
                 select(table)
@@ -598,4 +548,4 @@ class ObVecClient(ObClient):
                 stmt = stmt.where(*where_clause)
             with self.engine.connect() as conn:
                 with conn.begin():
-                    return _BufferedResult(conn.execute(stmt))
+                    return conn.execute(stmt).freeze()()

--- a/pyobvector/client/ob_vec_client.py
+++ b/pyobvector/client/ob_vec_client.py
@@ -1,6 +1,7 @@
 """OceanBase Vector Store Client."""
 
 import logging
+from collections.abc import Iterator
 from typing import Any
 
 import numpy as np
@@ -39,7 +40,7 @@ class _MappingsResult:
     def all(self) -> list[dict]:
         return list(self._data)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[dict]:
         return iter(self._data)
 
 
@@ -51,24 +52,24 @@ class _BufferedResult:
     wrapper fetches everything eagerly so the result stays valid.
     """
 
-    def __init__(self, cursor_result) -> None:
-        self._rows: list = cursor_result.fetchall()
+    def __init__(self, cursor_result: Any) -> None:
+        self._rows: list[tuple] = cursor_result.fetchall()
         self._keys: list[str] = list(cursor_result.keys())
 
-    def fetchall(self) -> list:
+    def fetchall(self) -> list[tuple]:
         rows, self._rows = self._rows, []
         return rows
 
-    def fetchone(self):
+    def fetchone(self) -> tuple | None:
         if not self._rows:
             return None
         row, self._rows = self._rows[0], self._rows[1:]
         return row
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple]:
         return iter(self._rows)
 
-    def all(self) -> list:
+    def all(self) -> list[tuple]:
         return self.fetchall()
 
     def keys(self) -> list[str]:

--- a/pyobvector/client/seekdb_engine.py
+++ b/pyobvector/client/seekdb_engine.py
@@ -5,6 +5,7 @@ work the same for both remote and embedded SeekDB.
 Requires optional dependency: pip install pyobvector[pyseekdb]
 """
 
+import logging
 import re
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -12,12 +13,36 @@ from typing import Any
 from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
+logger = logging.getLogger(__name__)
+
 _QUERY_SQL_PREFIXES = ("SELECT", "SHOW", "DESCRIBE", "DESC")
 
 
 def _is_query_sql(sql: str) -> bool:
     """Return True if sql is a row-returning statement (SELECT/SHOW/DESCRIBE/DESC)."""
     return sql.strip().upper().startswith(_QUERY_SQL_PREFIXES)
+
+
+def _description_from_select(sql: str) -> list[tuple]:
+    """Extract DBAPI description tuples from SELECT column list using sqlglot.
+
+    Falls back to [] when sqlglot cannot parse the statement (e.g. SHOW/DESCRIBE).
+    """
+    try:
+        import sqlglot
+        import sqlglot.expressions as exp
+
+        parsed = sqlglot.parse_one(sql)
+        if parsed is None or not hasattr(parsed, "selects"):
+            return []
+        cols = []
+        for sel in parsed.selects:
+            name = sel.alias or (sel.name if isinstance(sel, exp.Column) else sel.sql())
+            cols.append(name)
+        return [(c, None, None, None, None, None, None) for c in cols]
+    except Exception as e:
+        logger.debug("_description_from_select could not parse SQL: %s", e)
+        return []
 
 
 def _pyformat_to_format(sql: str, params: Any) -> tuple[str, list[Any]]:
@@ -57,10 +82,10 @@ class _SeekdbCursor:
     def execute(self, operation: str, parameters: Sequence[Any] | None = None) -> None:
         result = _execute_via_pyseekdb(self._client, operation, parameters or ())
         if not result:
-            # For SELECT/SHOW/DESCRIBE: use [] so SQLAlchemy treats this as a
-            # row-returning result with 0 rows, not a non-returning statement.
+            # For SELECT/SHOW/DESCRIBE: populate description so SQLAlchemy treats this
+            # as a row-returning result with 0 rows rather than a non-returning statement.
             # _NoResultMetaData (from None) would cause ResourceClosedError on fetchall().
-            self._description = [] if _is_query_sql(operation) else None
+            self._description = _description_from_select(operation) if _is_query_sql(operation) else None
             self._rows = []
             self.rowcount = 0
             return

--- a/pyobvector/client/seekdb_engine.py
+++ b/pyobvector/client/seekdb_engine.py
@@ -151,8 +151,7 @@ def create_engine_from_client(pyseekdb_client: Any, **kwargs: Any):
         poolclass=NullPool,
         **kwargs,
     )
-    # Attach server so callers can invoke server.refresh_index() for HNSW flush.
-    engine._seekdb_server = server
+    engine.update_execution_options(seekdb_server=server)
     return engine
 
 

--- a/pyobvector/client/seekdb_engine.py
+++ b/pyobvector/client/seekdb_engine.py
@@ -85,7 +85,11 @@ class _SeekdbCursor:
             # For SELECT/SHOW/DESCRIBE: populate description so SQLAlchemy treats this
             # as a row-returning result with 0 rows rather than a non-returning statement.
             # _NoResultMetaData (from None) would cause ResourceClosedError on fetchall().
-            self._description = _description_from_select(operation) if _is_query_sql(operation) else None
+            self._description = (
+                _description_from_select(operation)
+                if _is_query_sql(operation)
+                else None
+            )
             self._rows = []
             self.rowcount = 0
             return

--- a/pyobvector/client/seekdb_engine.py
+++ b/pyobvector/client/seekdb_engine.py
@@ -12,6 +12,13 @@ from typing import Any
 from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 
+_QUERY_SQL_PREFIXES = ("SELECT", "SHOW", "DESCRIBE", "DESC")
+
+
+def _is_query_sql(sql: str) -> bool:
+    """Return True if sql is a row-returning statement (SELECT/SHOW/DESCRIBE/DESC)."""
+    return sql.strip().upper().startswith(_QUERY_SQL_PREFIXES)
+
 
 def _pyformat_to_format(sql: str, params: Any) -> tuple[str, list[Any]]:
     """Convert SQLAlchemy pyformat (%(name)s) + dict params to %s + list for pyseekdb."""
@@ -50,7 +57,10 @@ class _SeekdbCursor:
     def execute(self, operation: str, parameters: Sequence[Any] | None = None) -> None:
         result = _execute_via_pyseekdb(self._client, operation, parameters or ())
         if not result:
-            self._description = None
+            # For SELECT/SHOW/DESCRIBE: use [] so SQLAlchemy treats this as a
+            # row-returning result with 0 rows, not a non-returning statement.
+            # _NoResultMetaData (from None) would cause ResourceClosedError on fetchall().
+            self._description = [] if _is_query_sql(operation) else None
             self._rows = []
             self.rowcount = 0
             return
@@ -135,12 +145,15 @@ def create_engine_from_client(pyseekdb_client: Any, **kwargs: Any):
     def creator() -> _SeekdbConnection:
         return _SeekdbConnection(server)
 
-    return create_engine(
+    engine = create_engine(
         "mysql+oceanbase://root:@127.0.0.1:2881/" + database,
         creator=creator,
         poolclass=NullPool,
         **kwargs,
     )
+    # Attach server so callers can invoke server.refresh_index() for HNSW flush.
+    engine._seekdb_server = server
+    return engine
 
 
 def create_embedded_engine(path: str, database: str = "test", **kwargs: Any):

--- a/tests/test_fts_index.py
+++ b/tests/test_fts_index.py
@@ -559,7 +559,7 @@ class FtsAnalyzerCompilationTest(unittest.TestCase):
         idx = self._build_index(props)
         sql = compile_create_fts_index(CreateFtsIndex(idx), _MockCompiler())
         self.assertIn("WITH PARSER analyzer", sql)
-        self.assertIn(f"PARSER_PROPERTIES = ({props})", sql)
+        self.assertIn(f"PARSER_PROPERTIES=({props})", sql)
 
     def test_fts_analyzer_requires_parser_properties(self):
         param = FtsIndexParam(
@@ -587,7 +587,7 @@ class FtsAnalyzerCompilationTest(unittest.TestCase):
         )
         sql = compile_create_fts_index(CreateFtsIndex(idx), _MockCompiler())
         self.assertIn("WITH PARSER ngram", sql)
-        self.assertIn("PARSER_PROPERTIES = (token_size = 2)", sql)
+        self.assertIn("PARSER_PROPERTIES=(token_size = 2)", sql)
 
     def test_make_analyzer_properties_default(self):
         result = make_analyzer_properties()


### PR DESCRIPTION
## Summary

Fixes two bugs that caused `ann_search` to always fail when using embedded SeekDB
(`ObVecClient(path=...)` / `SeekdbRemoteClient(path=...)`).

Also fixes two broken test assertions introduced by a Copilot suggestion on PR #65.

## Changes

- `seekdb_engine.py`: Set `cursor._description = []` (not `None`) when a SELECT/SHOW/DESCRIBE returns 0 rows, so SQLAlchemy creates a row-returning `CursorResult` instead of `_NoResultMetaData` — which raised `ResourceClosedError` on `fetchall()`.
- `seekdb_engine.py`: Store the embedded server reference via `engine.update_execution_options(seekdb_server=server)` (public API) so the flush helper can reach it without touching private Engine attributes.
- `ob_client.py`: Add `_flush_seekdb_index()` and call it at the end of `insert()`. HNSW index builds in seekdb are async; without an explicit flush, `ann_search` queries the index before it is built and returns 0 rows. The helper is a no-op for non-seekdb engines and for seekdb versions < 1.3.0. Refresh failures are demoted to a `logger.warning` so a flush error never aborts a successful write.
- `ob_vec_client.py`: Buffer results from `ann_search`, `post_ann_search`, and `precise_search` using `Result.freeze()()` (SQLAlchemy's built-in buffering) instead of a bespoke `_BufferedResult` wrapper. This preserves the full SQLAlchemy `Result` interface (`.first()`, `.scalars()`, `.mappings()`, etc.) for callers.
- `tests/test_fts_index.py`: Fix two assertions in `FtsAnalyzerCompilationTest` that expected `PARSER_PROPERTIES = (...)` with a space after `=`; the actual DDL output and reflection regex both use `PARSER_PROPERTIES=(...)` without a space.

## Motivation

With embedded SeekDB, every call to `ann_search` raised `sqlalchemy.exc.ResourceClosedError`. The root causes were:

1. **Connection lifetime**: `ann_search` returned `conn.execute()` directly from inside a `with engine.connect()` block. Once the block exited the connection closed, leaving callers with a dead `CursorResult`.
2. **Empty-SELECT cursor metadata**: When `_execute_via_pyseekdb` returns `[]` (e.g., HNSW index not yet built), `_SeekdbCursor` set `_description = None`, which caused SQLAlchemy to mark the result as non-row-returning.
3. **Async HNSW build**: seekdb builds HNSW indexes asynchronously. Any `ann_search` immediately after `insert` finds an empty index until a `CALL dbms_index_manager.refresh()` flush is issued (supported from seekdb ≥ 1.3.0).