### PR TITLE
fix: refresh embedded seekdb index after upsert

### DIFF
--- a/pyobvector/client/ob_client.py
+++ b/pyobvector/client/ob_client.py
@@ -159,7 +159,7 @@ class ObClient:
         return is_seekdb
 
     def _flush_seekdb_index(self) -> None:
-        """Flush async HNSW index builds in embedded seekdb after insert.
+        """Flush async HNSW index builds in embedded seekdb after a write.
 
         No-op when not using embedded seekdb or when the server does not expose
         a ``refresh_index`` method.
@@ -169,7 +169,7 @@ class ObClient:
             try:
                 server.refresh_index()
             except Exception as e:
-                logger.warning("seekdb index refresh failed after insert: %s", e)
+                logger.warning("seekdb index refresh failed after write: %s", e)
 
     def _insert_partition_hint_for_query_sql(self, sql: str, partition_hint: str):
         from_index = sql.find("FROM")
@@ -327,6 +327,7 @@ class ObClient:
                 )
                 upsert_stmt = upsert_stmt.values(data)
                 conn.execute(upsert_stmt)
+        self._flush_seekdb_index()
 
     def update(
         self,

--- a/tests/test_ob_client.py
+++ b/tests/test_ob_client.py
@@ -1,0 +1,27 @@
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from pyobvector.client.ob_client import ObClient
+
+
+class TestObClient(TestCase):
+    def test_upsert_refreshes_embedded_seekdb_index(self) -> None:
+        client = ObClient.__new__(ObClient)
+        client.engine = MagicMock()
+        client.metadata_obj = MagicMock()
+        client._flush_seekdb_index = MagicMock()
+
+        table = MagicMock()
+        upsert_statement = MagicMock()
+        upsert_statement.values.return_value = upsert_statement
+
+        with (
+            patch("pyobvector.client.ob_client.Table", return_value=table),
+            patch(
+                "pyobvector.client.ob_client.ReplaceStmt",
+                return_value=upsert_statement,
+            ),
+        ):
+            client.upsert("test_table", [{"id": "doc-1"}])
+
+        client._flush_seekdb_index.assert_called_once_with()


### PR DESCRIPTION
## Background

Embedded SeekDB 1.3+ builds vector indexes asynchronously. A caller that writes a record and immediately performs an ANN query can therefore miss that record until the pending index work is flushed.

`langchain-oceanbase` exposed this path because `OceanbaseVectorStore` writes through `pyobvector.ObClient.upsert()`. `ObClient.insert()` already flushes the embedded SeekDB index after a successful write, but `upsert()` did not.

## Why Fix This in pyobvector

The missing behavior is in pyobvector's shared write primitive, not in LangChain. Aligning `upsert()` with `insert()` here:

- Gives every direct and indirect pyobvector consumer the same read-after-write ANN behavior.
- Keeps embedded-SeekDB details behind pyobvector's existing `_flush_seekdb_index()` hook.
- Avoids a LangChain-only workaround that would duplicate backend-specific logic, depend on a private pyobvector implementation detail, and leave other users exposed.

A future `langchain-oceanbase` dependency update can then add an end-to-end embedded HNSW regression test against the released pyobvector fix.

## Change

Call the existing `_flush_seekdb_index()` hook after a successful `ObClient.upsert()` transaction, matching `insert()` behavior. The hook is already a no-op for non-embedded or unsupported backends, so remote OceanBase behavior is unchanged.

## Validation

- Added a regression test that confirms `upsert()` invokes the embedded refresh hook.
- Verified the test fails before the change and passes afterward.
- Ran Python compilation and staged-diff whitespace checks.

The broader embedded suite was attempted but is not counted as validation: the local `pylibseekdb 1.3.0.post2` environment fails during table creation before reaching `upsert()`.